### PR TITLE
Save Plane Info

### DIFF
--- a/nzgmdb/calculation/distances.py
+++ b/nzgmdb/calculation/distances.py
@@ -323,7 +323,6 @@ def get_nodal_plane_info(
             .to_dict(orient="records")
         )
 
-        # We can add single plane information
         nodal_plane_info["ztor"] = min(
             [plane.top_m / 1000 for plane in srf_model.planes]
         )

--- a/nzgmdb/data_processing/merge_flatfiles.py
+++ b/nzgmdb/data_processing/merge_flatfiles.py
@@ -219,9 +219,6 @@ def merge_flatfiles(main_dir: Path):
     site_basin_df = pd.read_csv(
         flatfile_dir / file_structure.PreFlatfileNames.SITE_TABLE
     )
-    plane_data_df = pd.read_csv(
-        flatfile_dir / file_structure.PreFlatfileNames.FAULT_PLANE_TABLE
-    )
 
     # Get the recorders information for location codes
     config = cfg.Config()
@@ -239,7 +236,6 @@ def merge_flatfiles(main_dir: Path):
     # Ensure that the other dfs only have the unique events
     event_df = event_df[event_df.evid.isin(unique_events)]
     phase_table_df = phase_table_df[phase_table_df.evid.isin(unique_events)]
-    plane_data_df = plane_data_df[plane_data_df.evid.isin(unique_events)]
 
     # Ensure that the site_basin_df only has the unique sites found in the im_df
     unique_sites = im_df["sta"].unique()
@@ -569,7 +565,4 @@ def merge_flatfiles(main_dir: Path):
     df_rotd100_flat.to_csv(
         flatfile_dir / file_structure.FlatfileNames.GROUND_MOTION_IM_ROTD100_FLAT,
         index=False,
-    )
-    plane_data_df.to_csv(
-        flatfile_dir / file_structure.FlatfileNames.FAULT_PLANE_TABLE, index=False
     )

--- a/nzgmdb/management/file_structure.py
+++ b/nzgmdb/management/file_structure.py
@@ -21,7 +21,6 @@ class PreFlatfileNames(StrEnum):
     SITE_TABLE = "site_table_all.csv"
     PROPAGATION_TABLE = "propagation_path_table_all.csv"
     GROUND_MOTION_IM_CATALOGUE = "ground_motion_im_catalogue.csv"
-    FAULT_PLANE_TABLE = "fault_plane_table_all.csv"
 
 
 class FlatfileNames(StrEnum):
@@ -47,7 +46,6 @@ class FlatfileNames(StrEnum):
     GROUND_MOTION_IM_ROTD50_FLAT = "ground_motion_im_table_rotd50_flat.csv"
     GROUND_MOTION_IM_ROTD100 = "ground_motion_im_table_rotd100.csv"
     GROUND_MOTION_IM_ROTD100_FLAT = "ground_motion_im_table_rotd100_flat.csv"
-    FAULT_PLANE_TABLE = "fault_plane_table.csv"
 
 
 class SkippedRecordFilenames(StrEnum):


### PR DESCRIPTION
Adds CCLD info to the earthquake source table to help for arthershock calculations etc.
Also adds in the avg strike, dip and rake for srf files based on the slip weighted average.
Adds corners if the srf is a single plane
Uses the min and max for dtop dbot and sum for length and width.
Extra check that srfModels is extracted before you run distance calculation, auto unpack if the zip exists otherwise throw and error.