### PR TITLE
n_proc fix

### DIFF
--- a/nzgmdb/phase_arrival/gen_phase_arrival_table.py
+++ b/nzgmdb/phase_arrival/gen_phase_arrival_table.py
@@ -105,6 +105,8 @@ def generate_phase_arrival_table(
     mseed_files = list(main_dir.rglob("*.mseed"))
 
     # Split them into even batches based on number of mseeds and n_procs
+    # Ensure n_procs gets reduced if it is greater than the number of mseed files
+    n_procs = min(n_procs, len(mseed_files))
     mseed_batches = np.array_split(mseed_files, n_procs)
 
     batches = [


### PR DESCRIPTION
For small running near real time events sometimes the set n_procs is less than the number of mseed files to compute for and so would run into issues during phasenet. This makes sure that doesn't happen