### PR TITLE
Install date

### DIFF
--- a/nzgmdb/data_retrieval/geonet.py
+++ b/nzgmdb/data_retrieval/geonet.py
@@ -224,6 +224,7 @@ def get_stations_within_radius(
     preferred_origin = event_cat.preferred_origin()
     event_lat = preferred_origin.latitude
     event_lon = preferred_origin.longitude
+    ev_datetime = preferred_origin.time
 
     # Get the max radius
     mags = mw_rrup_data[:, 0]
@@ -239,7 +240,7 @@ def get_stations_within_radius(
     maxradius = obspy.geodetics.kilometers2degrees(rrup)
 
     inv_sub = inventory.select(
-        latitude=event_lat, longitude=event_lon, maxradius=maxradius
+        latitude=event_lat, longitude=event_lon, maxradius=maxradius, starttime=ev_datetime, endtime=ev_datetime
     )
 
     return inv_sub

--- a/nzgmdb/data_retrieval/sites.py
+++ b/nzgmdb/data_retrieval/sites.py
@@ -42,9 +42,11 @@ def create_site_table_response() -> pd.DataFrame:
                     station.latitude,
                     station.longitude,
                     station.elevation,
+                    station.creation_date,
+                    station.end_date,
                 ]
             )
-    sta_df = pd.DataFrame(station_info, columns=["net", "sta", "lat", "lon", "elev"])
+    sta_df = pd.DataFrame(station_info, columns=["net", "sta", "lat", "lon", "elev", "creation_date", "end_date"])
     sta_df = sta_df.drop_duplicates().reset_index(drop=True)
 
     # Get the Geonet metadata summary information
@@ -100,6 +102,8 @@ def create_site_table_response() -> pd.DataFrame:
             "lat",
             "lon",
             "elev",
+            "creation_date",
+            "end_date",
             "site_class",
             "Vs30",
             "Vs30_std",


### PR DESCRIPTION
Adds the installation date to the site table
Also ensures when grabbing the radius for stations around an event that we filter by datetime of when the station is operational (This reduces the number of "No Waveform Data" requests that we send which should improve performance)