### PR TITLE
GMC Errors

### DIFF
--- a/nzgmdb/management/file_structure.py
+++ b/nzgmdb/management/file_structure.py
@@ -63,6 +63,7 @@ class SkippedRecordFilenames(StrEnum):
     PHASE_ARRIVAL_SKIPPED_RECORDS = "phase_arrival_skipped_records.csv"
     SNR_SKIPPED_RECORDS = "snr_skipped_records.csv"
     FMAX_SKIPPED_RECORDS = "fmax_skipped_records.csv"
+    GMC_SKIPPED_RECORDS = "gmc_skipped_records.csv"
     QUALITY_SKIPPED_RECORDS = "quality_skipped_records.csv"
 
 

--- a/nzgmdb/scripts/run_gmc.py
+++ b/nzgmdb/scripts/run_gmc.py
@@ -17,6 +17,71 @@ from qcore import cli
 app = typer.Typer(pretty_exceptions_enable=False)
 
 
+def get_gmc_errors(gmc_dir: Path):
+    """
+    Get all the GMC error files that had an issue during the execution
+
+    Parameters
+    ----------
+    gmc_dir : Path
+        The directory containing the GMC results.
+
+    Returns
+    -------
+    pd.DataFrame
+        A dataframe containing the record_id and reason for each error.
+    """
+    gmc_df = pd.DataFrame(columns=["record_id", "reason"])
+    for batch_dir in gmc_dir.iterdir():
+        for file in batch_dir.iterdir():
+            if file.is_dir():
+                for error_file in file.iterdir():
+                    # If the name of the error file is unknown then count the number of times the string
+                    # --------------------------------------------------------
+                    if "unknown" in error_file.stem:
+                        # Read the txt file and count the number of lines -1
+                        with open(error_file, "r") as f:
+                            lines = f.readlines()
+                            for line in lines:
+                                # Check if the line contains an .mseed file
+                                if ".mseed" in line:
+                                    # Add the name of the file to the found list
+                                    gmc_df = pd.concat(
+                                        [
+                                            gmc_df,
+                                            pd.DataFrame(
+                                                {
+                                                    "record_id": [
+                                                        line.split(",")[0].split(".")[0]
+                                                    ],
+                                                    "reason": ["unknown"],
+                                                }
+                                            ),
+                                        ]
+                                    )
+                    else:
+                        # Read the txt file and count the number of lines -1
+                        with open(error_file, "r") as f:
+                            lines = f.readlines()
+                            for line in lines[1:]:
+                                # Add the name of the file to the found list
+                                gmc_df = pd.concat(
+                                    [
+                                        gmc_df,
+                                        pd.DataFrame(
+                                            {
+                                                "record_id": [
+                                                    line.rstrip().split(".")[0]
+                                                ],
+                                                "reason": [error_file.stem],
+                                            }
+                                        ),
+                                    ]
+                                )
+
+    return gmc_df
+
+
 def process_batch(
     mseed_batch: list[Path],
     gmc_dir: Path,
@@ -211,6 +276,9 @@ def run_gmc_processing(
         file_structure.get_flatfile_dir(main_dir) if output_dir is None else output_dir
     )
     final_predictions_output = output_dir / file_structure.FlatfileNames.GMC_PREDICTIONS
+    gmc_errors_output = (
+        output_dir / file_structure.SkippedRecordFilenames.GMC_SKIPPED_RECORDS
+    )
 
     # Get the phase arrival table
     flatfile_dir = file_structure.get_flatfile_dir(main_dir)
@@ -266,12 +334,25 @@ def run_gmc_processing(
             )
     combined_df = pd.concat(dfs)
 
+    # Get the gmc errors
+    gmc_errors_df = get_gmc_errors(gmc_dir)
+
     # Check if the bypass records file exists
     if bypass_records_ffp is not None:
         bypass_df = pd.read_csv(bypass_records_ffp)
         # Merge in the bypass fmin values
         combined_df = combined_df.merge(
-            bypass_df[["record_id", "fmin_000", "fmin_090", "fmin_ver", "score_000", "score_090", "score_ver"]],
+            bypass_df[
+                [
+                    "record_id",
+                    "fmin_000",
+                    "fmin_090",
+                    "fmin_ver",
+                    "score_000",
+                    "score_090",
+                    "score_ver",
+                ]
+            ],
             left_on="record",
             right_on="record_id",
             how="left",
@@ -304,10 +385,19 @@ def run_gmc_processing(
 
         # Remove the bypass columns
         combined_df = combined_df.drop(
-            columns=["fmin_000", "fmin_090", "fmin_ver", "record_id_bypass", "score_000", "score_090", "score_ver"]
+            columns=[
+                "fmin_000",
+                "fmin_090",
+                "fmin_ver",
+                "record_id_bypass",
+                "score_000",
+                "score_090",
+                "score_ver",
+            ]
         )
 
     combined_df.to_csv(final_predictions_output, index=False)
+    gmc_errors_df.to_csv(gmc_errors_output, index=False)
 
 
 if __name__ == "__main__":

--- a/wiki/GMC.md
+++ b/wiki/GMC.md
@@ -109,8 +109,9 @@ python <gm_classifier_dir>/gm_classifier/scripts/predict.py <gmc_dir> <predictio
 
 After all batches complete processing:
 1. **Combine Batch Results** - Merges `gmc_predictions.csv` from all batch directories
-2. **Apply Bypass Records** - Incorporates any custom Fmin values from bypass file
-3. **Generate Final Output** - Creates consolidated `gmc_predictions.csv` in flatfiles directory
+2. **Collect Failed Records** - Gathers all failed records into a single dataframe for review
+3. **Apply Bypass Records** - Incorporates any custom Fmin values from bypass file
+4. **Generate Final Output** - Creates consolidated `gmc_predictions.csv` in flatfiles directory
 
 ---
 
@@ -142,6 +143,9 @@ Located in the flatfiles directory with the following columns:
 - `extract_features.log` - Feature extraction log file
 - `predict.log` - Prediction log file
 - `failed_records_*/` - Records that failed processing with error details
+
+**Summary of Failed Records:**
+- `gmc_skipped_records.csv` - Dataframe that contains record_ids and reason for failure
 
 **Log Files:**
 All processing logs are retained for debugging and quality assurance, including detailed error messages for failed records.


### PR DESCRIPTION
Adds a new skipped records file that pulls all of the failed record txt files that get generated by GMC for better understanding into why some records are skipped.